### PR TITLE
Add PTZ hook support via shared libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ jump_to_abs=/tmp/sd/yi-hack/bin/ipc_cmd -j %f,%f,%f
 jump_to_rel=/tmp/sd/yi-hack/bin/ipc_cmd -J %f,%f,%f
 get_presets=/tmp/sd/yi-hack/script/ptz_presets.sh -a get_presets
 
+You can also implement custom PTZ logic in a shared library. Prefix the command
+with `dl:` and specify the library path and symbol name separated by a colon.
+For example:
+
+```
+move_left=dl:/usr/local/lib/myptz.so:on_move_left
+```
+
+The library must export functions matching the expected signatures, e.g.:
+
+```c
+int on_move_left(double speed) { /* your code */ }
+```
+
+#RELAY OUTPUTS
+
 #RELAY OUTPUTS
 #Relay 0
 idle_state=open

--- a/conf.c
+++ b/conf.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
+#include <dlfcn.h>
 
 #include "cjson/cJSON.h"
 #include "conf.h"
@@ -30,6 +31,30 @@
 #include "onvif_simple_server.h"
 
 extern service_context_t service_ctx;
+
+static void *load_ptz_hook(const char *spec)
+{
+    if (spec == NULL)
+        return NULL;
+
+    if (strncmp(spec, "dl:", 3) != 0)
+        return NULL;
+
+    const char *p = spec + 3;
+    const char *sep = strrchr(p, ':');
+    if (sep == NULL)
+        return NULL;
+
+    char lib[PATH_MAX];
+    strncpy(lib, p, sep - p);
+    lib[sep - p] = '\0';
+
+    void *handle = dlopen(lib, RTLD_NOW);
+    if (handle == NULL)
+        return NULL;
+
+    return dlsym(handle, sep + 1);
+}
 
 int process_conf_file(char *file)
 {
@@ -92,6 +117,34 @@ int process_conf_file(char *file)
     service_ctx.ptz_node.remove_preset = NULL;
     service_ctx.ptz_node.jump_to_abs = NULL;
     service_ctx.ptz_node.jump_to_rel = NULL;
+    service_ctx.ptz_node.on_move_left = NULL;
+    service_ctx.ptz_node.on_move_right = NULL;
+    service_ctx.ptz_node.on_move_up = NULL;
+    service_ctx.ptz_node.on_move_down = NULL;
+    service_ctx.ptz_node.on_move_in = NULL;
+    service_ctx.ptz_node.on_move_out = NULL;
+    service_ctx.ptz_node.on_move_stop = NULL;
+    service_ctx.ptz_node.on_move_preset = NULL;
+    service_ctx.ptz_node.on_goto_home_position = NULL;
+    service_ctx.ptz_node.on_set_preset = NULL;
+    service_ctx.ptz_node.on_set_home_position = NULL;
+    service_ctx.ptz_node.on_remove_preset = NULL;
+    service_ctx.ptz_node.on_jump_to_abs = NULL;
+    service_ctx.ptz_node.on_jump_to_rel = NULL;
+    service_ctx.ptz_node.on_move_left = NULL;
+    service_ctx.ptz_node.on_move_right = NULL;
+    service_ctx.ptz_node.on_move_up = NULL;
+    service_ctx.ptz_node.on_move_down = NULL;
+    service_ctx.ptz_node.on_move_in = NULL;
+    service_ctx.ptz_node.on_move_out = NULL;
+    service_ctx.ptz_node.on_move_stop = NULL;
+    service_ctx.ptz_node.on_move_preset = NULL;
+    service_ctx.ptz_node.on_goto_home_position = NULL;
+    service_ctx.ptz_node.on_set_preset = NULL;
+    service_ctx.ptz_node.on_set_home_position = NULL;
+    service_ctx.ptz_node.on_remove_preset = NULL;
+    service_ctx.ptz_node.on_jump_to_abs = NULL;
+    service_ctx.ptz_node.on_jump_to_rel = NULL;
 
     while(fgets(line, MAX_LEN, fF)) {
         char *first = line;
@@ -292,6 +345,20 @@ int process_conf_file(char *file)
             service_ctx.ptz_node.remove_preset = NULL;
             service_ctx.ptz_node.jump_to_abs = NULL;
             service_ctx.ptz_node.jump_to_rel = NULL;
+            service_ctx.ptz_node.on_move_left = NULL;
+            service_ctx.ptz_node.on_move_right = NULL;
+            service_ctx.ptz_node.on_move_up = NULL;
+            service_ctx.ptz_node.on_move_down = NULL;
+            service_ctx.ptz_node.on_move_in = NULL;
+            service_ctx.ptz_node.on_move_out = NULL;
+            service_ctx.ptz_node.on_move_stop = NULL;
+            service_ctx.ptz_node.on_move_preset = NULL;
+            service_ctx.ptz_node.on_goto_home_position = NULL;
+            service_ctx.ptz_node.on_set_preset = NULL;
+            service_ctx.ptz_node.on_set_home_position = NULL;
+            service_ctx.ptz_node.on_remove_preset = NULL;
+            service_ctx.ptz_node.on_jump_to_abs = NULL;
+            service_ctx.ptz_node.on_jump_to_rel = NULL;
         } else if (strcasecmp(param, "min_step_x") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
                 if (value[0] == '\0') {
@@ -418,73 +485,143 @@ int process_conf_file(char *file)
             }
         } else if (strcasecmp(param, "move_left") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_left = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_left, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_left = (int (*)(double)) sym;
+                } else {
+                    service_ctx.ptz_node.move_left = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_left, value);
+                }
             }
         } else if (strcasecmp(param, "move_right") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_right = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_right, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_right = (int (*)(double)) sym;
+                } else {
+                    service_ctx.ptz_node.move_right = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_right, value);
+                }
             }
         } else if (strcasecmp(param, "move_up") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_up = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_up, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_up = (int (*)(double)) sym;
+                } else {
+                    service_ctx.ptz_node.move_up = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_up, value);
+                }
             }
         } else if (strcasecmp(param, "move_down") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_down = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_down, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_down = (int (*)(double)) sym;
+                } else {
+                    service_ctx.ptz_node.move_down = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_down, value);
+                }
             }
         } else if (strcasecmp(param, "move_in") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_in = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_in, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_in = (int (*)(double)) sym;
+                } else {
+                    service_ctx.ptz_node.move_in = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_in, value);
+                }
             }
         } else if (strcasecmp(param, "move_out") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_out = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_out, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_out = (int (*)(double)) sym;
+                } else {
+                    service_ctx.ptz_node.move_out = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_out, value);
+                }
             }
         } else if (strcasecmp(param, "move_stop") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_stop = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_stop, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_stop = (int (*)(const char *)) sym;
+                } else {
+                    service_ctx.ptz_node.move_stop = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_stop, value);
+                }
             }
         } else if (strcasecmp(param, "move_preset") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.move_preset = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.move_preset, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_move_preset = (int (*)(int)) sym;
+                } else {
+                    service_ctx.ptz_node.move_preset = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.move_preset, value);
+                }
             }
         } else if (strcasecmp(param, "goto_home_position") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.goto_home_position = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.goto_home_position, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_goto_home_position = (int (*)(void)) sym;
+                } else {
+                    service_ctx.ptz_node.goto_home_position = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.goto_home_position, value);
+                }
             }
         } else if (strcasecmp(param, "set_preset") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.set_preset = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.set_preset, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_set_preset = (int (*)(int, const char *)) sym;
+                } else {
+                    service_ctx.ptz_node.set_preset = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.set_preset, value);
+                }
             }
         } else if (strcasecmp(param, "set_home_position") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.set_home_position = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.set_home_position, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_set_home_position = (int (*)(void)) sym;
+                } else {
+                    service_ctx.ptz_node.set_home_position = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.set_home_position, value);
+                }
             }
         } else if (strcasecmp(param, "remove_preset") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.remove_preset = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.remove_preset, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_remove_preset = (int (*)(int)) sym;
+                } else {
+                    service_ctx.ptz_node.remove_preset = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.remove_preset, value);
+                }
             }
         } else if (strcasecmp(param, "jump_to_abs") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.jump_to_abs = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.jump_to_abs, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_jump_to_abs = (int (*)(double, double, double)) sym;
+                } else {
+                    service_ctx.ptz_node.jump_to_abs = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.jump_to_abs, value);
+                }
             }
         } else if (strcasecmp(param, "jump_to_rel") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
-                service_ctx.ptz_node.jump_to_rel = (char *) malloc(strlen(value) + 1);
-                strcpy(service_ctx.ptz_node.jump_to_rel, value);
+                void *sym = load_ptz_hook(value);
+                if (sym != NULL) {
+                    service_ctx.ptz_node.on_jump_to_rel = (int (*)(double, double, double)) sym;
+                } else {
+                    service_ctx.ptz_node.jump_to_rel = (char *) malloc(strlen(value) + 1);
+                    strcpy(service_ctx.ptz_node.jump_to_rel, value);
+                }
             }
         } else if (strcasecmp(param, "get_presets") == 0) {
             if (service_ctx.ptz_node.enable == 1) {
@@ -882,20 +1019,160 @@ int process_json_conf_file(char *file)
         get_double_from_json(&(service_ctx.ptz_node.max_step_z), value, "max_step_z");
         get_string_from_json(&(service_ctx.ptz_node.get_position), value, "get_position");
         get_string_from_json(&(service_ctx.ptz_node.is_moving), value, "is_moving");
-        get_string_from_json(&(service_ctx.ptz_node.move_left), value, "move_left");
-        get_string_from_json(&(service_ctx.ptz_node.move_right), value, "move_right");
-        get_string_from_json(&(service_ctx.ptz_node.move_up), value, "move_up");
-        get_string_from_json(&(service_ctx.ptz_node.move_down), value, "move_down");
-        get_string_from_json(&(service_ctx.ptz_node.move_in), value, "move_in");
-        get_string_from_json(&(service_ctx.ptz_node.move_out), value, "move_out");
-        get_string_from_json(&(service_ctx.ptz_node.move_stop), value, "move_stop");
-        get_string_from_json(&(service_ctx.ptz_node.move_preset), value, "move_preset");
-        get_string_from_json(&(service_ctx.ptz_node.goto_home_position), value, "goto_home_position");
-        get_string_from_json(&(service_ctx.ptz_node.set_preset), value, "set_preset");
-        get_string_from_json(&(service_ctx.ptz_node.set_home_position), value, "set_home_position");
-        get_string_from_json(&(service_ctx.ptz_node.remove_preset), value, "remove_preset");
-        get_string_from_json(&(service_ctx.ptz_node.jump_to_abs), value, "jump_to_abs");
-        get_string_from_json(&(service_ctx.ptz_node.jump_to_rel), value, "jump_to_rel");
+        char *tmp = NULL;
+        get_string_from_json(&tmp, value, "move_left");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_left = (int (*)(double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_left = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_right");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_right = (int (*)(double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_right = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_up");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_up = (int (*)(double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_up = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_down");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_down = (int (*)(double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_down = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_in");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_in = (int (*)(double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_in = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_out");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_out = (int (*)(double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_out = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_stop");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_stop = (int (*)(const char *)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_stop = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "move_preset");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_move_preset = (int (*)(int)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.move_preset = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "goto_home_position");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_goto_home_position = (int (*)(void)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.goto_home_position = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "set_preset");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_set_preset = (int (*)(int, const char *)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.set_preset = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "set_home_position");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_set_home_position = (int (*)(void)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.set_home_position = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "remove_preset");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_remove_preset = (int (*)(int)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.remove_preset = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "jump_to_abs");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_jump_to_abs = (int (*)(double, double, double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.jump_to_abs = tmp;
+            }
+        }
+        tmp = NULL;
+        get_string_from_json(&tmp, value, "jump_to_rel");
+        if (tmp != NULL) {
+            void *sym = load_ptz_hook(tmp);
+            if (sym != NULL) {
+                service_ctx.ptz_node.on_jump_to_rel = (int (*)(double, double, double)) sym;
+                free(tmp);
+            } else {
+                service_ctx.ptz_node.jump_to_rel = tmp;
+            }
+        }
         get_string_from_json(&(service_ctx.ptz_node.get_presets), value, "get_presets");
 
         // Print debug

--- a/onvif_simple_server.h
+++ b/onvif_simple_server.h
@@ -94,6 +94,22 @@ typedef struct {
     char *jump_to_abs;
     char *jump_to_rel;
     char *get_presets;
+
+    /* Optional hooks loaded from shared libraries */
+    int (*on_move_left)(double);
+    int (*on_move_right)(double);
+    int (*on_move_up)(double);
+    int (*on_move_down)(double);
+    int (*on_move_in)(double);
+    int (*on_move_out)(double);
+    int (*on_move_stop)(const char *);
+    int (*on_move_preset)(int);
+    int (*on_goto_home_position)(void);
+    int (*on_set_preset)(int, const char *);
+    int (*on_set_home_position)(void);
+    int (*on_remove_preset)(int);
+    int (*on_jump_to_abs)(double, double, double);
+    int (*on_jump_to_rel)(double, double, double);
 } ptz_node_t;
 
 typedef struct {

--- a/ptz_service.c
+++ b/ptz_service.c
@@ -409,13 +409,18 @@ int ptz_goto_preset()
         send_fault("ptz_service", "Sender", "ter:InvalidArgVal", "ter:NoToken", "No token", "The requested preset token does not exist");
         return -4;
     }
-    if (service_ctx.ptz_node.move_preset == NULL) {
+    if ((service_ctx.ptz_node.move_preset == NULL) &&
+            (service_ctx.ptz_node.on_move_preset == NULL)) {
         send_action_failed_fault("ptz_service", -5);
         return -5;
     }
 
-    sprintf(sys_command, service_ctx.ptz_node.move_preset, preset_number);
-    system(sys_command);
+    if (service_ctx.ptz_node.on_move_preset != NULL) {
+        service_ctx.ptz_node.on_move_preset(preset_number);
+    } else {
+        sprintf(sys_command, service_ctx.ptz_node.move_preset, preset_number);
+        system(sys_command);
+    }
     long size = cat(NULL, "ptz_service_files/GotoPreset.xml", 0);
 
     fprintf(stdout, "Content-type: application/soap+xml\r\n");
@@ -439,11 +444,16 @@ int ptz_goto_home_position()
         return -2;
     }
 
-    if (service_ctx.ptz_node.goto_home_position == NULL) {
+    if ((service_ctx.ptz_node.goto_home_position == NULL) &&
+            (service_ctx.ptz_node.on_goto_home_position == NULL)) {
         send_action_failed_fault("ptz_service", -3);
         return -3;
     }
-    system(service_ctx.ptz_node.goto_home_position);
+    if (service_ctx.ptz_node.on_goto_home_position != NULL) {
+        service_ctx.ptz_node.on_goto_home_position();
+    } else {
+        system(service_ctx.ptz_node.goto_home_position);
+    }
 
     long size = cat(NULL, "ptz_service_files/GotoHomePosition.xml", 0);
 
@@ -491,21 +501,29 @@ int ptz_continuous_move()
         dx = atof(x);
 
         if (dx > 0.0) {
-            if (service_ctx.ptz_node.move_right == NULL) {
+            if (service_ctx.ptz_node.on_move_right != NULL) {
+                service_ctx.ptz_node.on_move_right(dx);
+                ret = 0;
+            } else if (service_ctx.ptz_node.move_right != NULL) {
+                sprintf(sys_command, service_ctx.ptz_node.move_right, dx);
+                system(sys_command);
+                ret = 0;
+            } else {
                 send_action_failed_fault("ptz_service", -3);
                 return -3;
             }
-            sprintf(sys_command, service_ctx.ptz_node.move_right, dx);
-            system(sys_command);
-            ret = 0;
         } else if (dx < 0.0) {
-            if (service_ctx.ptz_node.move_left == NULL) {
+            if (service_ctx.ptz_node.on_move_left != NULL) {
+                service_ctx.ptz_node.on_move_left(-dx);
+                ret = 0;
+            } else if (service_ctx.ptz_node.move_left != NULL) {
+                sprintf(sys_command, service_ctx.ptz_node.move_left, -dx);
+                system(sys_command);
+                ret = 0;
+            } else {
                 send_action_failed_fault("ptz_service", -4);
                 return -4;
             }
-            sprintf(sys_command, service_ctx.ptz_node.move_left, -dx);
-            system(sys_command);
-            ret = 0;
         }
     }
 
@@ -513,21 +531,29 @@ int ptz_continuous_move()
         dy = atof(y);
 
         if (dy > 0.0) {
-            if (service_ctx.ptz_node.move_up == NULL) {
+            if (service_ctx.ptz_node.on_move_up != NULL) {
+                service_ctx.ptz_node.on_move_up(dy);
+                ret = 0;
+            } else if (service_ctx.ptz_node.move_up != NULL) {
+                sprintf(sys_command, service_ctx.ptz_node.move_up, dy);
+                system(sys_command);
+                ret = 0;
+            } else {
                 send_action_failed_fault("ptz_service", -5);
                 return -5;
             }
-            sprintf(sys_command, service_ctx.ptz_node.move_up, dy);
-            system(sys_command);
-            ret = 0;
         } else if (dy < 0.0) {
-            if (service_ctx.ptz_node.move_down == NULL) {
+            if (service_ctx.ptz_node.on_move_down != NULL) {
+                service_ctx.ptz_node.on_move_down(-dy);
+                ret = 0;
+            } else if (service_ctx.ptz_node.move_down != NULL) {
+                sprintf(sys_command, service_ctx.ptz_node.move_down, -dy);
+                system(sys_command);
+                ret = 0;
+            } else {
                 send_action_failed_fault("ptz_service", -6);
                 return -6;
             }
-            sprintf(sys_command, service_ctx.ptz_node.move_down, -dy);
-            system(sys_command);
-            ret = 0;
         }
     }
 
@@ -535,21 +561,29 @@ int ptz_continuous_move()
         dz = atof(z);
 
         if (dz > 0.0) {
-            if (service_ctx.ptz_node.move_in == NULL) {
+            if (service_ctx.ptz_node.on_move_in != NULL) {
+                service_ctx.ptz_node.on_move_in(dz);
+                ret = 0;
+            } else if (service_ctx.ptz_node.move_in != NULL) {
+                sprintf(sys_command, service_ctx.ptz_node.move_in, dz);
+                system(sys_command);
+                ret = 0;
+            } else {
                 send_action_failed_fault("ptz_service", -7);
                 return -7;
             }
-            sprintf(sys_command, service_ctx.ptz_node.move_in, dz);
-            system(sys_command);
-            ret = 0;
         } else if (dz < 0.0) {
-            if (service_ctx.ptz_node.move_out == NULL) {
+            if (service_ctx.ptz_node.on_move_out != NULL) {
+                service_ctx.ptz_node.on_move_out(-dz);
+                ret = 0;
+            } else if (service_ctx.ptz_node.move_out != NULL) {
+                sprintf(sys_command, service_ctx.ptz_node.move_out, -dz);
+                system(sys_command);
+                ret = 0;
+            } else {
                 send_action_failed_fault("ptz_service", -8);
                 return -8;
             }
-            sprintf(sys_command, service_ctx.ptz_node.move_out, -dz);
-            system(sys_command);
-            ret = 0;
         }
     }
 
@@ -685,7 +719,11 @@ int ptz_relative_move()
     }
 
     if (ret == 0) {
-        system(sys_command);
+        if (service_ctx.ptz_node.on_jump_to_rel != NULL) {
+            service_ctx.ptz_node.on_jump_to_rel(dx, dy, dz);
+        } else {
+            system(sys_command);
+        }
 
         long size = cat(NULL, "ptz_service_files/RelativeMove.xml", 0);
 
@@ -774,7 +812,11 @@ int ptz_absolute_move()
     }
 
     if (ret == 0) {
-        system(sys_command);
+        if (service_ctx.ptz_node.on_jump_to_abs != NULL) {
+            service_ctx.ptz_node.on_jump_to_abs(dx, dy, dz);
+        } else {
+            system(sys_command);
+        }
 
         long size = cat(NULL, "ptz_service_files/AbsoluteMove.xml", 0);
 
@@ -807,7 +849,8 @@ int ptz_stop()
         return -2;
     }
 
-    if (service_ctx.ptz_node.move_stop == NULL) {
+    if ((service_ctx.ptz_node.move_stop == NULL) &&
+            (service_ctx.ptz_node.on_move_stop == NULL)) {
         send_action_failed_fault("ptz_service", -3);
         return -3;
     }
@@ -822,14 +865,26 @@ int ptz_stop()
     }
 
     if (pantilt && zoom) {
-        sprintf(sys_command, service_ctx.ptz_node.move_stop, "all");
-        system(sys_command);
+        if (service_ctx.ptz_node.on_move_stop != NULL) {
+            service_ctx.ptz_node.on_move_stop("all");
+        } else {
+            sprintf(sys_command, service_ctx.ptz_node.move_stop, "all");
+            system(sys_command);
+        }
     } else if (pantilt) {
-        sprintf(sys_command, service_ctx.ptz_node.move_stop, "pantilt");
-        system(sys_command);
+        if (service_ctx.ptz_node.on_move_stop != NULL) {
+            service_ctx.ptz_node.on_move_stop("pantilt");
+        } else {
+            sprintf(sys_command, service_ctx.ptz_node.move_stop, "pantilt");
+            system(sys_command);
+        }
     } else if (zoom) {
-        sprintf(sys_command, service_ctx.ptz_node.move_stop, "zoom");
-        system(sys_command);
+        if (service_ctx.ptz_node.on_move_stop != NULL) {
+            service_ctx.ptz_node.on_move_stop("zoom");
+        } else {
+            sprintf(sys_command, service_ctx.ptz_node.move_stop, "zoom");
+            system(sys_command);
+        }
     }
 
     long size = cat(NULL, "ptz_service_files/Stop.xml", 0);
@@ -1041,7 +1096,8 @@ int ptz_set_preset()
         }
     }
 
-    if (service_ctx.ptz_node.set_preset == NULL) {
+    if ((service_ctx.ptz_node.set_preset == NULL) &&
+            (service_ctx.ptz_node.on_set_preset == NULL)) {
         destroy_presets();
         send_action_failed_fault("ptz_service", -9);
         return -9;
@@ -1050,8 +1106,12 @@ int ptz_set_preset()
     destroy_presets();
 
     // Unhandled race condition
-    sprintf(sys_command, service_ctx.ptz_node.set_preset, preset_number, (char *) preset_name_out);
-    system(sys_command);
+    if (service_ctx.ptz_node.on_set_preset != NULL) {
+        service_ctx.ptz_node.on_set_preset(preset_number, preset_name_out);
+    } else {
+        sprintf(sys_command, service_ctx.ptz_node.set_preset, preset_number, (char *) preset_name_out);
+        system(sys_command);
+    }
     sleep(1);
 
     init_presets();
@@ -1095,13 +1155,17 @@ int ptz_set_home_position()
         return -2;
     }
 
-    if (service_ctx.ptz_node.set_home_position == NULL) {
+    if ((service_ctx.ptz_node.set_home_position == NULL) &&
+            (service_ctx.ptz_node.on_set_home_position == NULL)) {
         send_action_failed_fault("ptz_service", -3);
         return -3;
     }
-
-    strcpy(sys_command, service_ctx.ptz_node.set_home_position);
-    system(sys_command);
+    if (service_ctx.ptz_node.on_set_home_position != NULL) {
+        service_ctx.ptz_node.on_set_home_position();
+    } else {
+        strcpy(sys_command, service_ctx.ptz_node.set_home_position);
+        system(sys_command);
+    }
 
     long size = cat(NULL, "ptz_service_files/SetHomePosition.xml", 0);
 
@@ -1134,13 +1198,17 @@ int ptz_remove_preset()
         return -3;
     }
 
-    if (service_ctx.ptz_node.remove_preset == NULL) {
+    if ((service_ctx.ptz_node.remove_preset == NULL) &&
+            (service_ctx.ptz_node.on_remove_preset == NULL)) {
         send_action_failed_fault("ptz_service", -4);
         return -4;
     }
-
-    sprintf(sys_command, service_ctx.ptz_node.remove_preset, preset_number);
-    system(sys_command);
+    if (service_ctx.ptz_node.on_remove_preset != NULL) {
+        service_ctx.ptz_node.on_remove_preset(preset_number);
+    } else {
+        sprintf(sys_command, service_ctx.ptz_node.remove_preset, preset_number);
+        system(sys_command);
+    }
 
     long size = cat(NULL, "ptz_service_files/RemovePreset.xml", 0);
 


### PR DESCRIPTION
## Summary
- extend `ptz_node_t` with optional function pointers
- add loader for PTZ hooks in `conf.c`
- allow configuration entries prefixed with `dl:` to load custom hooks
- call hooks in PTZ service when provided
- document hook usage in README

## Testing
- `make` *(fails: cjson headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68405c9f60ac8333a30cb7684e0270b4