### PR TITLE
Add GetCapabilities hook

### DIFF
--- a/device_service.c
+++ b/device_service.c
@@ -30,6 +30,13 @@
 
 extern service_context_t service_ctx;
 
+static device_get_capabilities_hook_t get_capabilities_hook = NULL;
+
+void register_device_get_capabilities_hook(device_get_capabilities_hook_t hook)
+{
+    get_capabilities_hook = hook;
+}
+
 int device_get_services()
 {
     int ret = 0;
@@ -490,6 +497,13 @@ int device_get_capabilities()
         sprintf(audio_outputs, "%d", 1);
     } else {
         sprintf(audio_outputs, "%d", 0);
+    }
+
+    if (get_capabilities_hook) {
+        int hook_ret = get_capabilities_hook(icategory, &service_ctx);
+        if (hook_ret != 0) {
+            return hook_ret;
+        }
     }
 
     if (icategory == 1) {

--- a/device_service.h
+++ b/device_service.h
@@ -17,6 +17,8 @@
 #ifndef DEVICE_SERVICE_H
 #define DEVICE_SERVICE_H
 
+#include "onvif_simple_server.h"
+
 int device_get_services();
 int device_get_service_capabilities();
 int device_get_device_information();
@@ -25,6 +27,8 @@ int device_system_reboot();
 int device_get_scopes();
 int device_get_users();
 int device_get_wsdl_url();
+typedef int (*device_get_capabilities_hook_t)(int category, service_context_t *ctx);
+void register_device_get_capabilities_hook(device_get_capabilities_hook_t hook);
 int device_get_capabilities();
 int device_get_network_interfaces();
 int device_get_discovery_mode();


### PR DESCRIPTION
## Summary
- add optional hook for GetCapabilities in device service
- expose hook registration function in header

## Testing
- `cargo fmt --all -- --check` *(fails: command not found)*
- `cargo test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68405fc9d6608333969ec79ae1723c8b